### PR TITLE
Fix (ci): Allow publish-to-psgallery job in ci-master-pr to read secret NUGET_API_KEY

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -257,6 +257,8 @@ jobs:
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
     - name: Publish
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
         set -e
 


### PR DESCRIPTION
Fixes job failing in https://github.com/leojonathanoh/Type-Pwsh/actions/runs/813704038